### PR TITLE
Enable filters & searchable fields for the array grid provider

### DIFF
--- a/ProviderHandler/ArrayHandler.php
+++ b/ProviderHandler/ArrayHandler.php
@@ -73,6 +73,33 @@ class ArrayHandler implements ProviderHandlerInterface
             });
         }
 
+        foreach($gridState->getFilters() as $filter) {
+            $items = match($filter->getConditionType()) {
+                'like' => array_filter($items, function (DataObject $item) use ($filter) {
+                    return str_contains((string)$item->getData($filter->getField()), (string)$filter->getValue());
+                }),
+                'equals' => array_filter($items, function (DataObject $item) use ($filter) {
+                    return (string)$item->getData($filter->getField()) === (string)$filter->getValue();
+                }),
+                'from_to' => array_filter($items, function (DataObject $item) use ($filter) {
+                    $fieldValue = $item->getData($filter->getField());
+
+                    $from = $filter->getValue()['from'] ?? '';
+                    if ($from !== '' && $fieldValue < $from) {
+                        return false;
+                    }
+
+                    $to = $filter->getValue()['to'] ?? '';
+                    if ($to !== '' && $fieldValue > $to) {
+                        return false;
+                    }
+
+                    return true;
+                }),
+                default => $items
+            };
+        }
+
         $sortField = $gridState->getSortBy();
         $sortDirection = $gridState->getSortDirection();
         if (!empty($sortField)) {


### PR DESCRIPTION
This PR does the following:

* Allows you to limit searchable fields for an array grid. If you specify them in layout xml then only those fields will be searched. If you don't set this, you still get the old behavior.
* Allows you to filter ArrayProvider based grids, using the 'like', 'equals' and 'from_to' condition types.

I've tested these in the module I'm building here: https://github.com/LBannenberg/magento2-composer-dashboard, although I had to twist the from_to a bit because I'm not using that directly.

I didn't have a clear example of the 'in' condition type being used, it seemed like you might want to use it for a multiselect situation (customer groups, stores)? Without a good example of it in action, I haven't implemented that, so you'd safely fall through to the default case (line 99).